### PR TITLE
Png bugfix

### DIFF
--- a/src/main/java/de/swa/gmaf/PluginChain.java
+++ b/src/main/java/de/swa/gmaf/PluginChain.java
@@ -108,21 +108,20 @@ public class PluginChain {
 									ByteArrayOutputStream baos = new ByteArrayOutputStream();
 									boolean returnValue = ImageIO.write(section, "jpg", baos);
 									if (!returnValue) {
-										throw new RuntimeException("Could not write subsesction image");
+										throw new RuntimeException("Could not create subimage from image '" + f.getName() + "'");
 									}
 									baos.flush();
 									byte[] sectionBytes = baos.toByteArray();
 									baos.close();
 
-									String filename = "temp/section_" + fvp.getClass().getName() + "_" + System.currentTimeMillis() + ".jpg";
-									FileOutputStream fout = new FileOutputStream(new File(filename));
+									FileOutputStream fout = new FileOutputStream(new File("temp/section_"
+											+ fvp.getClass().getName() + "_" + System.currentTimeMillis() + ".jpg"));
 									ImageIO.write(section, "jpg", fout);
 
-									fout.close();
 									// reprocess parts of this image
 									System.out.println(
-											depth_offset + "  reprocessing TA " + ta.getWidth() + " " + ta.getHeight() + "(filename: " + filename + "; bytes: " + sectionBytes.length + ")");
-									MMFG newImg = new GMAF().processAsset(sectionBytes, filename, "tmp", depth--,
+											depth_offset + "  reprocessing TA " + ta.getWidth() + " " + ta.getHeight());
+									MMFG newImg = new GMAF().processAsset(sectionBytes, "section.jpg", "tmp", depth--,
 											max, f.getName(), null);
 
 									FeatureVectorBuilder.mergeIntoFeatureVector(fv, newImg);


### PR DESCRIPTION
Without the change, PNG images with alpha channel will cause exceptions later in the plugin change. This is because the subimage will not be written by ImageIO, if there is no proper writer for JPG with alpha channel. The change converts the subimage into a RGB, alpha channels will be "black".

It can be discussed, if this should be based on file extension of if image has transparency, which can be done via a get function.